### PR TITLE
Disable the class-methods-use-this rule

### DIFF
--- a/src/rules/best-practices.js
+++ b/src/rules/best-practices.js
@@ -16,5 +16,6 @@ module.exports = {
     'vars-on-top': 'error',
     'wrap-iife': ['error', 'any'],
     yoda: ['error', 'never'],
+    'class-methods-use-this': 'off',
   },
 };


### PR DESCRIPTION
Disable the [class-method-use-this](https://eslint.org/docs/4.0.0/rules/class-methods-use-this) rule.

See the [js-toolkit PR](https://github.com/studiometa/js-toolkit/pull/2/files#r385567556) for more details. 