### PR TITLE
Add more precise `env` configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,16 @@ module.exports = {
     sourceType: 'module',
   },
   env: {
+    browser: true,
     es6: true,
   },
   overrides: [
+    {
+      files: '**/*.js',
+      parser: 'babel-eslint',
+    },
     require('./overrides/build-files'),
+    require('./overrides/jest'),
     require('./overrides/prettier'),
     require('./overrides/vue'),
   ],

--- a/src/overrides/build-files.js
+++ b/src/overrides/build-files.js
@@ -1,5 +1,8 @@
 module.exports = {
   files: ['gulpfile.js', 'webpack.mix.js', '.*rc.js', '*.config.js'],
+  env: {
+    node: true,
+  },
   rules: {
     'global-require': 'off',
     'import/no-extraneous-dependencies': ['warn', { devDependencies: true }],

--- a/src/overrides/jest.js
+++ b/src/overrides/jest.js
@@ -1,0 +1,6 @@
+module.exports = {
+  files: ['**/*.spec.js'],
+  env: {
+    jest: true,
+  },
+};


### PR DESCRIPTION
ESLint allow to [define environments](https://eslint.org/docs/user-guide/configuring.html#specifying-environments) to automatically enable global variables, this PR adds the `browser` env to the default list of environments and `node` to the build files override.