### PR TITLE
BREAKING CHANGE: Always require file extension for imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,23 +9,7 @@ module.exports = {
     require.resolve('./rules/es6.js'),
   ],
   rules: {
-    'import/extensions': [
-      'error',
-      'always',
-      {
-        js: 'never',
-        mjs: 'never',
-        jsx: 'never',
-        vue: 'never',
-      },
-    ],
-  },
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.vue', '.mjs', '.jsx'],
-      },
-    },
+    'import/extensions': ['error', 'always'],
   },
   parser: 'babel-eslint',
   env: {

--- a/src/overrides/build-files.js
+++ b/src/overrides/build-files.js
@@ -1,5 +1,14 @@
 module.exports = {
-  files: ['gulpfile.js', 'webpack.mix.js', '.*rc.js', '*.config.js'],
+  files: [
+    'gulpfile.js',
+    'webpack.mix.js',
+    '.*rc.js',
+    '.*rc.mjs',
+    '.*rc.cjs',
+    '*.config.js',
+    '*.config.mjs',
+    '*.config.cjs',
+  ],
   env: {
     node: true,
   },

--- a/src/overrides/jest.js
+++ b/src/overrides/jest.js
@@ -1,5 +1,5 @@
 module.exports = {
-  files: ['**/*.spec.js'],
+  files: ['**/*.spec.js', '**/*.spec.mjs', '**/*.spec.cjs'],
   env: {
     jest: true,
   },

--- a/src/overrides/prettier.js
+++ b/src/overrides/prettier.js
@@ -1,4 +1,4 @@
 module.exports = {
-  files: ['*.js'],
+  files: ['*.js', '*.mjs', '*.cjs'],
   extends: ['plugin:prettier/recommended'],
 };


### PR DESCRIPTION
As the JS ecosystem grows towards modules, using file extensions for imports is becoming the norm (see Node.js modules and https://github.com/vitejs/vite/issues/178#issuecomment-630138450 for Vue). 

This PR updates the ESLint rule `import/extension` to always require file extension.

This is a breaking change.