### PR TITLE
ci: migrate from git-flow to trunk-based (main branch)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: build
 on:
   push:
     branches:
-      - master
-      - develop
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Changes

- Replace `master`/`develop` branch triggers with `main` in CI workflows
- Part of migration from git-flow (master/develop) to trunk-based development (main)

## Migration steps done
1. ✅ Merged develop into master (fast-forward)
2. ✅ Renamed master → main
3. ✅ Set main as default branch
4. ✅ Retargeted all open PRs to main
5. ✅ Updated CI workflow triggers

## After merge
- Delete `develop` and `master` remote branches
- Delete stale branches (release/*, depfu/*, dependabot/*, renovate/*)